### PR TITLE
docs: port docs generator to python3

### DIFF
--- a/docs/ElunaDoc/__main__.py
+++ b/docs/ElunaDoc/__main__.py
@@ -1,14 +1,14 @@
 import os
 import shutil
-from types import FileType
+import typing
 from jinja2 import Environment, FileSystemLoader
 from typedecorator import params, returns
-from parser import ClassParser, MethodDoc
+from ElunaDoc.parser import ClassParser, MethodDoc
 import glob
 import time
 
 
-@returns([(str, FileType)])
+@returns([(str, typing.IO)])
 @params(search_path=str)
 def find_class_files(search_path):
     """Find and open all files containing Eluna class methods in `search_path`.
@@ -63,13 +63,13 @@ if __name__ == '__main__':
     shutil.copytree('ElunaDoc/static', 'build/static')
 
     # Load up all files with methods we need to parse.
-    print 'Finding Eluna method files...'
+    print('Finding Eluna method files...')
     class_files = find_class_files('../')
 
     # Parse all the method files.
     classes = []
     for f in class_files:
-        print 'Parsing file {}...'.format(f.name)
+        print(f'Parsing file {f.name}...')
         classes.append(ClassParser.parse_file(f))
         f.close()
 
@@ -155,7 +155,7 @@ if __name__ == '__main__':
     render('date.js', 'date.js', level=0, currdate=time.strftime("%d/%m/%Y"))
 
     for class_ in classes:
-        print 'Rending pages for class {}...'.format(class_.name)
+        print(f'Rendering pages for class {class_.name}...')
 
         # Make a folder for the class.
         os.mkdir('build/' + class_.name)

--- a/docs/ElunaDoc/parser.py
+++ b/docs/ElunaDoc/parser.py
@@ -1,5 +1,5 @@
 import re
-from types import FileType
+import typing
 import markdown
 from typedecorator import params, returns, Nullable
 
@@ -23,7 +23,7 @@ class ParameterDoc(object):
         'ObjectGuid': ('0', '18,446,744,073,709,551,615'),
     }
 
-    @params(self=object, name=Nullable(unicode), data_type=str, description=unicode, default_value=Nullable(unicode))
+    @params(self=object, name=Nullable(str), data_type=str, description=str, default_value=Nullable(str))
     def __init__(self, name, data_type, description, default_value=None):
         """If `name` is not provided, the Parameter is a returned value instead of a parameter."""
         self.name = name
@@ -59,12 +59,12 @@ class ParameterDoc(object):
             self.data_type = '[' + self.data_type + ']'
 
         elif not self.data_type in ['nil', 'boolean', 'number', 'string', 'table', 'function', '...'] and self.data_type[:1] != '[':
-            print "Missing angle brackets [] around the data type name: `" + self.data_type + "`"
+            print(f"Missing angle brackets [] around the data type name: `{self.data_type}`")
 
 
 class MethodDoc(object):
     """The documentation data of an Eluna method."""
-    @params(self=object, name=unicode, description=unicode, prototypes=[unicode], parameters=[ParameterDoc], returned=[ParameterDoc])
+    @params(self=object, name=str, description=str, prototypes=[str], parameters=[ParameterDoc], returned=[ParameterDoc])
     def __init__(self, name, description, prototypes, parameters, returned):
         self.name = name
         self.prototypes = prototypes
@@ -81,7 +81,7 @@ class MethodDoc(object):
 
 class MangosClassDoc(object):
     """The documentation of a MaNGOS class that has Lua methods."""
-    @params(self=object, name=unicode, description=unicode, methods=[MethodDoc])
+    @params(self=object, name=str, description=str, methods=[MethodDoc])
     def __init__(self, name, description, methods):
         self.name = name
         # Parse the description as Markdown.
@@ -317,7 +317,7 @@ class ClassParser(object):
 
     @staticmethod
     @returns(MangosClassDoc)
-    @params(file=FileType)
+    @params(file=typing.IO)
     def parse_file(file):
         """Parse the file `file` into a documented class."""
         # Get the class name from "ClassMethods.h" by stripping off "Methods.h".


### PR DESCRIPTION
This allows building the web documentation with Python 3 instead of Python 2.
The build process stays the same (see [DOC_GEN.md](/azerothcore/Eluna/blob/master/docs/DOC_GEN.md)):
```sh
$ cd LuaEngine/docs/
$ python -m ElunaDoc
```

Pre-requisites:
```
$ python -m pip install jinja2 typedecorator markdown
```