### PR TITLE
feat: add chat handler methods

### DIFF
--- a/ChatHandlerMethods.h
+++ b/ChatHandlerMethods.h
@@ -1,0 +1,192 @@
+/*
+* Copyright (C) 2010 - 2016 Eluna Lua Engine <http://emudevs.com/>
+* This program is free software licensed under GPL version 3
+* Please see the included DOCS/LICENSE.md for more information
+*/
+
+#ifndef CHATHANDLERMETHODS_H
+#define CHATHANDLERMETHODS_H
+
+#include "Chat.h"
+
+namespace LuaChatHandler
+{
+    /**
+     * Sends text to the chat handler
+     *
+     * @proto (text)
+     * @proto (entry)
+     * @param string text : text to display in chat or console
+     * @param uint32 entry : id of the string to display
+     */
+    int SendSysMessage(lua_State* L, ChatHandler* handler)
+    {
+        if (lua_isnumber(L, 2))
+        {
+            uint32 entry = Eluna::CHECKVAL<uint32>(L, 2);
+            handler->SendSysMessage(entry);
+        }
+        else
+        {
+            std::string text = Eluna::CHECKVAL<std::string>(L, 2);
+            handler->SendSysMessage(text);
+        }
+        return 0;
+    }
+
+    /**
+     * Returns `true` if the [ChatHandler] comes from the console, `false` if it comes from a player
+     *
+     * @return bool isConsole
+     */
+    int IsConsole(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->IsConsole());
+        return 1;
+    }
+
+    /**
+     * Returns the [Player] associated with the handler. Returns `nil` in the case of a console handler
+     *
+     * @return [Player] player
+     */
+    int GetPlayer(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->GetPlayer());
+        return 1;
+    }
+
+    /**
+     * Sends a message to all connected players
+     *
+     * @param string text : text to send
+     */
+    int SendGlobalSysMessage(lua_State* L, ChatHandler* handler)
+    {
+        std::string text = Eluna::CHECKVAL<std::string>(L, 2);
+        handler->SendGlobalSysMessage(text.c_str());
+        return 0;
+    }
+
+    /**
+     * Sends a message to all connected Game Masters
+     *
+     * @param string text : text to send
+     */
+    int SendGlobalGMSysMessage(lua_State* L, ChatHandler* handler)
+    {
+        std::string text = Eluna::CHECKVAL<std::string>(L, 2);
+        handler->SendGlobalGMSysMessage(text.c_str());
+        return 0;
+    }
+
+    /**
+     * Checks if the current security level is lower than the specified [Player]'s account
+     *
+     * @param [Player] player
+     * @param [bool] strong = false : Forces non-player accounts (security level greater than `0`) to go through the regular check if set to `true`.<br>Also, if set to `true`, the current security level will be considered as lower than the [Player]'s security level if the two levels are equal
+     * @return [bool] lower
+     */
+    int HasLowerSecurity(lua_State* L, ChatHandler* handler)
+    {
+        Player* player = Eluna::CHECKOBJ<Player>(L, 2);
+        bool strong = Eluna::CHECKVAL<bool>(L, 3);
+        Eluna::Push(L, handler->HasLowerSecurity(player, ObjectGuid::Empty, strong));
+        return 1;
+    }
+
+    /**
+     * Checks if the current security level is lower than the specified `account`'s level
+     *
+     * @param [uint32] account : the target account ID to compare security levels with
+     * @param [bool] strong = false : Forces non-player accounts (security level greater than `0`) to go through the regular check if set to `true`.<br>Also, if set to `true`, the current security level will be considered as lower than the `account`'s security level if the two levels are equal
+     * @return [bool] lower
+     */
+    int HasLowerSecurityAccount(lua_State* L, ChatHandler* handler)
+    {
+        uint32 account = Eluna::CHECKVAL<uint32>(L, 2);
+        bool strong = Eluna::CHECKVAL<bool>(L, 3);
+        Eluna::Push(L, handler->HasLowerSecurityAccount(nullptr, account, strong));
+        return 1;
+    }
+
+    /**
+     * Returns the selected [Player]
+     *
+     * @return [Player] player
+     */
+    int GetSelectedPlayer(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->getSelectedPlayer());
+        return 1;
+    }
+
+    /**
+     * Returns the selected [Creature]
+     *
+     * @return [Creature] creature
+     */
+    int GetSelectedCreature(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->getSelectedCreature());
+        return 1;
+    }
+
+    /**
+     * Returns the selected [Unit]
+     *
+     * @return [Unit] unit
+     */
+    int GetSelectedUnit(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->getSelectedUnit());
+        return 1;
+    }
+
+    /**
+     * Returns the selected [WorldObject]
+     *
+     * @return [WorldObject] object
+     */
+    int GetSelectedObject(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->getSelectedObject());
+        return 1;
+    }
+
+    /**
+     * Returns the selected [Player] or the current [Player] if nothing is targeted or the target is not a player
+     *
+     * @return [Player] player
+     */
+    int GetSelectedPlayerOrSelf(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->getSelectedPlayerOrSelf());
+        return 1;
+    }
+
+    /**
+     * Checks if the `securityLevel` is available
+     *
+     * @param [uint32] securityLevel
+     * @return [bool] isAvailable
+     */
+    int IsAvailable(lua_State* L, ChatHandler* handler)
+    {
+        uint32 securityLevel = Eluna::CHECKVAL<uint32>(L, 2);
+        Eluna::Push(L, handler->IsAvailable(securityLevel));
+        return 1;
+    }
+
+    /**
+     * Returns `true` if other previously called [ChatHandler] methods sent an error
+     *
+     * @return [bool] sentErrorMessage
+     */
+    int HasSentErrorMessage(lua_State* L, ChatHandler* handler)
+    {
+        Eluna::Push(L, handler->HasSentErrorMessage());
+        return 1;
+    }
+}
+#endif

--- a/GlobalMethods.h
+++ b/GlobalMethods.h
@@ -704,7 +704,7 @@ namespace LuaGlobalFunctions
      *     PLAYER_EVENT_ON_LEARN_TALENTS           =     39,       // (event, player, talentId, talentRank, spellid)
      *     // UNUSED                               =     40,       // (event, player)
      *     // UNUSED                               =     41,       // (event, player)
-     *     PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
+     *     PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command, chatHandler) - player is nil if command used from console. Can return false
      *     PLAYER_EVENT_ON_PET_ADDED_TO_WORLD      =     43,       // (event, player, pet)
      * };
      * </pre>

--- a/Hooks.h
+++ b/Hooks.h
@@ -203,7 +203,7 @@ namespace Hooks
         PLAYER_EVENT_ON_LEARN_TALENTS           =     39,       // (event, player, talentId, talentRank, spellid)
         // UNUSED                               =     40,       // (event, player)
         // UNUSED                               =     41,       // (event, player)
-        PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command) - player is nil if command used from console. Can return false
+        PLAYER_EVENT_ON_COMMAND                 =     42,       // (event, player, command, chatHandler) - player is nil if command used from console. Can return false
         PLAYER_EVENT_ON_PET_ADDED_TO_WORLD      =     43,       // (event, player, pet)
 
         PLAYER_EVENT_COUNT

--- a/LuaEngine.h
+++ b/LuaEngine.h
@@ -13,6 +13,7 @@
 
 #include "Group.h"
 #include "Item.h"
+#include "Chat.h"
 #ifndef TRINITY
 #include "Player.h"
 #endif
@@ -353,7 +354,7 @@ public:
 
     /* Custom */
     void OnTimedEvent(int funcRef, uint32 delay, uint32 calls, WorldObject* obj);
-    bool OnCommand(Player* player, const char* text);
+    bool OnCommand(ChatHandler& handler, const char* text);
     void OnWorldUpdate(uint32 diff);
     void OnLootItem(Player* pPlayer, Item* pItem, uint32 count, ObjectGuid guid);
     void OnLootMoney(Player* pPlayer, uint32 amount);

--- a/LuaFunctions.cpp
+++ b/LuaFunctions.cpp
@@ -36,6 +36,7 @@ extern "C"
 #include "CorpseMethods.h"
 #include "VehicleMethods.h"
 #include "BattleGroundMethods.h"
+#include "ChatHandlerMethods.h"
 
 luaL_Reg GlobalMethods[] =
 {
@@ -1296,6 +1297,26 @@ ElunaRegister<BattleGround> BattleGroundMethods[] =
     { NULL, NULL }
 };
 
+ElunaRegister<ChatHandler> ChatHandlerMethods[] =
+{
+    { "SendSysMessage", &LuaChatHandler::SendSysMessage },
+    { "IsConsole", &LuaChatHandler::IsConsole },
+    { "GetPlayer", &LuaChatHandler::GetPlayer },
+    { "SendGlobalSysMessage", &LuaChatHandler::SendGlobalSysMessage },
+    { "SendGlobalGMSysMessage", &LuaChatHandler::SendGlobalGMSysMessage },
+    { "HasLowerSecurity", &LuaChatHandler::HasLowerSecurity },
+    { "HasLowerSecurityAccount", &LuaChatHandler::HasLowerSecurityAccount },
+    { "GetSelectedPlayer", &LuaChatHandler::GetSelectedPlayer },
+    { "GetSelectedCreature", &LuaChatHandler::GetSelectedCreature },
+    { "GetSelectedUnit", &LuaChatHandler::GetSelectedUnit },
+    { "GetSelectedObject", &LuaChatHandler::GetSelectedObject },
+    { "GetSelectedPlayerOrSelf", &LuaChatHandler::GetSelectedPlayerOrSelf },
+    { "IsAvailable", &LuaChatHandler::IsAvailable },
+    { "HasSentErrorMessage", &LuaChatHandler::HasSentErrorMessage },
+
+    { NULL, NULL }
+};
+
 #if (!defined(TBC) && !defined(CLASSIC))
 // fix compile error about accessing vehicle destructor
 template<> int ElunaTemplate<Vehicle>::CollectGarbage(lua_State* L)
@@ -1428,6 +1449,9 @@ void RegisterFunctions(Eluna* E)
 
     ElunaTemplate<BattleGround>::Register(E, "BattleGround");
     ElunaTemplate<BattleGround>::SetMethods(E, BattleGroundMethods);
+
+    ElunaTemplate<ChatHandler>::Register(E, "ChatHandler");
+    ElunaTemplate<ChatHandler>::SetMethods(E, ChatHandlerMethods);
 
     ElunaTemplate<WorldPacket>::Register(E, "WorldPacket", true);
     ElunaTemplate<WorldPacket>::SetMethods(E, PacketMethods);

--- a/PlayerHooks.cpp
+++ b/PlayerHooks.cpp
@@ -39,8 +39,9 @@ void Eluna::OnLearnTalents(Player* pPlayer, uint32 talentId, uint32 talentRank, 
     CallAllFunctions(PlayerEventBindings, key);
 }
 
-bool Eluna::OnCommand(Player* player, const char* text)
+bool Eluna::OnCommand(ChatHandler& handler, const char* text)
 {
+    Player* player = handler.IsConsole() ? nullptr : handler.GetSession()->GetPlayer();
     // If from console, player is NULL
     if (!player || player->GetSession()->GetSecurity() >= SEC_ADMINISTRATOR)
     {
@@ -56,6 +57,7 @@ bool Eluna::OnCommand(Player* player, const char* text)
     START_HOOK_WITH_RETVAL(PLAYER_EVENT_ON_COMMAND, true);
     Push(player);
     Push(text);
+    Push(&handler);
     return CallAllFunctionsBool(PlayerEventBindings, key, true);
 }
 


### PR DESCRIPTION
* Adds class `ChatHandler`
    * `GetPlayer()`
    * `GetSelectedCreature()`
    * `GetSelectedObject()`
    * `GetSelectedPlayer()`
    * `GetSelectedPlayerOrSelf()`
    * `GetSelectedUnit()`
    * `HasLowerSecurity()`
    * `HasLowerSecurityAccount()`
    * `HasSentErrorMessage()`
    * `IsAvailable()`
    * `IsConsole()`
    * `SendGlobalGMSysMessage()`
    * `SendGlobalSysMessage()`
    * `SendSysMessage()`
* Adds `ChatHandler` argument passed to `PLAYER_EVENT_ON_COMMAND` hook
    * The arguments are now `(event, player, command, chatHandler)`
    * Example usage:
```lua
local PLAYER_EVENT_ON_COMMAND = 42

RegisterPlayerEvent(PLAYER_EVENT_ON_COMMAND, function(event, player, text, chatHandler)
	if text ~= "testcmd" then
		return true
	end

	if not chatHandler:IsAvailable(3) then
		-- Restrict usage to sec level 3 and higher
		return true
	end

	chatHandler:SendSysMessage("Test command!") -- Gets printed to the chat if ran from a player, and printed to console otherwise
	return false
end)
```

This PR needs https://github.com/azerothcore/mod-eluna-lua-engine/pull/89